### PR TITLE
Add docstring annotations to the entire public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Import the Geckoboard package and create an instance of the client using your AP
 ```python
 import geckoboard
 
-client = geckbooard.client(API_KEY)
+client = geckoboard.client(API_KEY)
 ```
 
 **Note:** You can find your API key by logging into the Geckoboard application and visiting the Account section.

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ your API key:
 
     import geckoboard
 
-    client = geckbooard.client(API_KEY)
+    client = geckoboard.client(API_KEY)
 
 **Note:** You can find your API key by logging into the Geckoboard
 application and visiting the Account section.

--- a/geckoboard/__init__.py
+++ b/geckoboard/__init__.py
@@ -1,4 +1,5 @@
 from geckoboard.client import Client
 
+
 def client(api_key):
-  return Client(api_key)
+    return Client(api_key)

--- a/geckoboard/__init__.py
+++ b/geckoboard/__init__.py
@@ -1,5 +1,34 @@
+"""
+The official Geckoboard API client for Python
+
+The Geckoboard API client can authenticate you
+and connect you to our datasets API so that
+you can create, update and delete datasets.
+"""
+
 from geckoboard.client import Client
 
 
 def client(api_key):
+    """
+    Creates an instance of a Geckoboard API client
+
+    The Geckoboard API client can authenticate you and connect you
+    to our datasets API.
+
+    Note
+    ----
+    You can find your API key by logging into the Geckoboard application
+    and visiting the Account section.
+
+    Parameters
+    ----------
+    api_key : str
+        Your Geckoboard API key
+
+    Returns
+    -------
+    Client
+        A Geckoboard API client instance
+    """
     return Client(api_key)

--- a/geckoboard/api.py
+++ b/geckoboard/api.py
@@ -2,14 +2,18 @@ import requests
 
 API_HOST = 'https://api.geckoboard.com'
 
+
 def get(path, api_key):
-  return requests.get(API_HOST + path, auth=(api_key, ''))
+    return requests.get(API_HOST + path, auth=(api_key, ''))
+
 
 def delete(path, api_key):
-  return requests.delete(API_HOST + path, auth=(api_key, ''))
+    return requests.delete(API_HOST + path, auth=(api_key, ''))
+
 
 def post(path, body, api_key):
-  return requests.post(API_HOST + path, json=body, auth=(api_key, ''))
+    return requests.post(API_HOST + path, json=body, auth=(api_key, ''))
+
 
 def put(path, body, api_key):
-  return requests.put(API_HOST + path, json=body, auth=(api_key, ''))
+    return requests.put(API_HOST + path, json=body, auth=(api_key, ''))

--- a/geckoboard/api.py
+++ b/geckoboard/api.py
@@ -1,3 +1,7 @@
+"""
+Private: api access methods
+"""
+
 import requests
 
 API_HOST = 'https://api.geckoboard.com'

--- a/geckoboard/client.py
+++ b/geckoboard/client.py
@@ -1,14 +1,15 @@
 from geckoboard.connection import Connection
 from geckoboard.datasets_client import DatasetsClient
 
+
 class Client():
-  def __init__(self, api_key):
-    connection = Connection(api_key)
-    
-    self.__connection = connection
-    self.datasets = DatasetsClient(connection)
+    def __init__(self, api_key):
+        connection = Connection(api_key)
 
-  def ping(self):
-    self.__connection.get('/')
+        self.__connection = connection
+        self.datasets = DatasetsClient(connection)
 
-    return True
+    def ping(self):
+        self.__connection.get('/')
+
+        return True

--- a/geckoboard/client.py
+++ b/geckoboard/client.py
@@ -1,8 +1,34 @@
+"""
+Public class: Client
+"""
+
 from geckoboard.connection import Connection
 from geckoboard.datasets_client import DatasetsClient
 
 
 class Client():
+    """
+    The Geckoboard API client
+
+    The Geckoboard API client can authenticate you and connect you
+    to our datasets API.
+
+    Note
+    ----
+    You can find your API key by logging into the Geckoboard application
+    and visiting the Account section.
+
+    Parameters
+    ----------
+    api_key : str
+        Your Geckoboard API key
+
+    Attributes
+    ----------
+    datasets : DatasetsClient
+        The datasets client can find, create and delete your datasets
+    """
+
     def __init__(self, api_key):
         connection = Connection(api_key)
 
@@ -10,6 +36,22 @@ class Client():
         self.datasets = DatasetsClient(connection)
 
     def ping(self):
+        """
+        Checks that your API key is valid and that you can reach the Geckoboard API
+
+        Returns
+        -------
+        bool
+            True if you are authenticated successfully
+
+        Raises
+        ------
+        Exception
+            If your API key is invalid
+
+        ConnectionError
+            If you could not connect to the Geckoboard API
+        """
         self.__connection.get('/')
 
         return True

--- a/geckoboard/connection.py
+++ b/geckoboard/connection.py
@@ -1,3 +1,10 @@
+"""
+Private class: Connection
+
+A utility wrapper for containing API details and exposing
+simplified API access methods.
+"""
+
 from geckoboard import api
 from geckoboard import response_handler
 

--- a/geckoboard/connection.py
+++ b/geckoboard/connection.py
@@ -1,29 +1,29 @@
-import json
 from geckoboard import api
 from geckoboard import response_handler
 
+
 class Connection():
-  def __init__(self, api_key):
-    self.api_key = api_key
+    def __init__(self, api_key):
+        self.api_key = api_key
 
-  def get(self, path):
-    response = api.get(path, self.api_key)
-    return self.handle_response(response)
+    def get(self, path):
+        response = api.get(path, self.api_key)
+        return self.handle_response(response)
 
-  def delete(self, path):
-    response = api.delete(path, self.api_key)
-    return self.handle_response(response)
+    def delete(self, path):
+        response = api.delete(path, self.api_key)
+        return self.handle_response(response)
 
-  def post(self, path, body):
-    response = api.post(path, body, self.api_key)
-    return self.handle_response(response)
+    def post(self, path, body):
+        response = api.post(path, body, self.api_key)
+        return self.handle_response(response)
 
-  def put(self, path, body):
-    response = api.put(path, body, self.api_key)
-    return self.handle_response(response)
+    def put(self, path, body):
+        response = api.put(path, body, self.api_key)
+        return self.handle_response(response)
 
-  def handle_response(self, response):
-    if response.status_code < 200 or response.status_code >= 300:
-      raise Exception(response_handler.get_error_message(response))
+    def handle_response(self, response):
+        if response.status_code < 200 or response.status_code >= 300:
+            raise Exception(response_handler.get_error_message(response))
 
-    return response
+        return response

--- a/geckoboard/dataset.py
+++ b/geckoboard/dataset.py
@@ -1,9 +1,44 @@
+"""
+Public class: Dataset
+"""
+
+
 class Dataset():
+    """
+    Update or delete an individual dataset.
+
+    Parameters
+    ----------
+    dataset_id : str
+        The name of the dataset
+    """
+
     def __init__(self, dataset_id, connection):
         self.__id = dataset_id
         self.__connection = connection
 
     def put(self, items):
+        """
+        Replace all data entries in the Dataset
+
+        Parameters
+        ----------
+        items : list
+            A list of the entries to replace the current ones
+
+        Returns
+        -------
+        bool
+            True if the dataset was successfully updated
+
+        Raises
+        ------
+        Exception
+            If the items do not match the dataset schema
+
+        ConnectionError
+            If you could not connect to the Geckoboard API
+        """
         body = {
             'data': items,
         }
@@ -13,6 +48,27 @@ class Dataset():
         return True
 
     def post(self, items, delete_by=None):
+        """
+        Append new data entries to the Dataset
+
+        Parameters
+        ----------
+        items : list
+            A list of the entries to append to the current ones
+
+        Returns
+        -------
+        bool
+            True if the dataset was successfully updated
+
+        Raises
+        ------
+        Exception
+            If the items do not match the dataset schema
+
+        ConnectionError
+            If you could not connect to the Geckoboard API
+        """
         body = {
             'data': items,
         }
@@ -25,6 +81,19 @@ class Dataset():
         return True
 
     def delete(self):
+        """
+        Delete the dataset
+
+        Returns
+        -------
+        bool
+            True if the dataset was successfully updated
+
+        Raises
+        ------
+        ConnectionError
+            If you could not connect to the Geckoboard API
+        """
         self.__connection.delete('/datasets/' + self.__id)
 
         return True

--- a/geckoboard/dataset.py
+++ b/geckoboard/dataset.py
@@ -1,30 +1,30 @@
 class Dataset():
-  def __init__(self, id, connection):
-    self.__id = id
-    self.__connection = connection
+    def __init__(self, dataset_id, connection):
+        self.__id = dataset_id
+        self.__connection = connection
 
-  def put(self, items):
-    body = {
-      'data': items,
-    }
+    def put(self, items):
+        body = {
+            'data': items,
+        }
 
-    self.__connection.put('/datasets/' + self.__id + '/data', body)
+        self.__connection.put('/datasets/' + self.__id + '/data', body)
 
-    return True
+        return True
 
-  def post(self, items, delete_by=None):
-    body = {
-      'data': items,
-    }
+    def post(self, items, delete_by=None):
+        body = {
+            'data': items,
+        }
 
-    if delete_by is not None:
-      body['delete_by'] = delete_by
+        if delete_by is not None:
+            body['delete_by'] = delete_by
 
-    self.__connection.post('/datasets/' + self.__id + '/data', body)
+        self.__connection.post('/datasets/' + self.__id + '/data', body)
 
-    return True
+        return True
 
-  def delete(self):
-    self.__connection.delete('/datasets/' + self.__id)
+    def delete(self):
+        self.__connection.delete('/datasets/' + self.__id)
 
-    return True
+        return True

--- a/geckoboard/datasets_client.py
+++ b/geckoboard/datasets_client.py
@@ -1,22 +1,23 @@
 from geckoboard.dataset import Dataset
 
+
 class DatasetsClient():
-  def __init__(self, connection):
-    self.__connection = connection
+    def __init__(self, connection):
+        self.__connection = connection
 
-  def find_or_create(self, dataset_id, fields, unique_by=None):
-    body = {
-      'fields': fields,
-    }
+    def find_or_create(self, dataset_id, fields, unique_by=None):
+        body = {
+            'fields': fields,
+        }
 
-    if unique_by is not None:
-      body['unique_by'] = unique_by
+        if unique_by is not None:
+            body['unique_by'] = unique_by
 
-    self.__connection.put('/datasets/' + dataset_id, body)
+        self.__connection.put('/datasets/' + dataset_id, body)
 
-    return Dataset(dataset_id, self.__connection)
+        return Dataset(dataset_id, self.__connection)
 
-  def delete(self, dataset_id):
-    self.__connection.delete('/datasets/' + dataset_id)
+    def delete(self, dataset_id):
+        self.__connection.delete('/datasets/' + dataset_id)
 
-    return True
+        return True

--- a/geckoboard/datasets_client.py
+++ b/geckoboard/datasets_client.py
@@ -1,11 +1,56 @@
+"""
+Public class: DatasetsClient
+"""
+
 from geckoboard.dataset import Dataset
 
 
 class DatasetsClient():
+    """
+    The datasets API client
+
+    The datasets API client can find, create and delete your datasets.
+    """
+
     def __init__(self, connection):
         self.__connection = connection
 
     def find_or_create(self, dataset_id, fields, unique_by=None):
+        """
+        Creates a new, or returns an existing dataset
+
+        Searches for a dataset with a matching ID and schema. If a
+        match is found that dataset is returned. Otherwise, a new
+        dataset is created and returned.
+
+        The dataset instance that is returned allows you
+        to update or delete that dataset.
+
+        Parameters
+        ----------
+        dataset_id : str
+            The name of the dataset
+
+        fields : dict
+            The dataset schema (see https://developer.geckoboard.com/api-reference/python/#types)
+
+        unique_by : list
+            A list of schema keys (fields) that must have unique values for each entry
+
+        Returns
+        -------
+        Dataset
+            A new dataset instance
+
+        Raises
+        ------
+        Exception
+            If your API key is invalid or an existing dataset is found
+            with a schema that doesn't match the one provided
+
+        ConnectionError
+            If you could not connect to the Geckoboard API
+        """
         body = {
             'fields': fields,
         }
@@ -18,6 +63,32 @@ class DatasetsClient():
         return Dataset(dataset_id, self.__connection)
 
     def delete(self, dataset_id):
+        """
+        Deletes a dataset by ID
+
+        Allows you to delete a dataset with a given ID. You can
+        also delete a dataset by calling the `delete` method
+        on the dataset instance.
+
+        Parameters
+        ----------
+        dataset_id : str
+            The name of the dataset
+
+        Returns
+        -------
+        bool
+            True if the dataset was successfully deleted
+
+        Raises
+        ------
+        Exception
+            If your API key is invalid or no dataset was found
+            that matches the ID provided
+
+        ConnectionError
+            If you could not connect to the Geckoboard API
+        """
         self.__connection.delete('/datasets/' + dataset_id)
 
         return True

--- a/geckoboard/response_handler.py
+++ b/geckoboard/response_handler.py
@@ -1,2 +1,7 @@
+"""
+Private: requests response utility methods
+"""
+
+
 def get_error_message(response):
     return response.json()['error']['message']

--- a/geckoboard/response_handler.py
+++ b/geckoboard/response_handler.py
@@ -1,2 +1,2 @@
 def get_error_message(response):
-  return response.json()['error']['message']
+    return response.json()['error']['message']

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,27 @@
 from setuptools import setup
 
+
 def readme():
-    with open('README.rst') as f:
-        return f.read()
+    with open('README.rst') as readme_file:
+        return readme_file.read()
+
 
 setup(
-  name='geckoboard.py',
-  version='0.2.7',
-  description='Official Python client for the Geckoboard Datasets API',
-  long_description=readme(),
-  url='https://github.com/geckoboard/geckoboard-python',
-  author='Geckoboard',
-  author_email='dan@geckoboard.com',
-  license='MIT',
-  keywords=['geckoboard', 'datasets', 'api', 'python'],
-  packages=['geckoboard'],
-  install_requires=['requests'],
-  tests_require=['nose', 'mock'],
-  classifiers=[
-    'Development Status :: 4 - Beta',
-    'Intended Audience :: Developers',
-    'License :: OSI Approved :: MIT License'
-  ]
+    name='geckoboard.py',
+    version='0.2.7',
+    description='Official Python client for the Geckoboard Datasets API',
+    long_description=readme(),
+    url='https://github.com/geckoboard/geckoboard-python',
+    author='Geckoboard',
+    author_email='dan@geckoboard.com',
+    license='MIT',
+    keywords=['geckoboard', 'datasets', 'api', 'python'],
+    packages=['geckoboard'],
+    install_requires=['requests'],
+    tests_require=['nose', 'mock'],
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License'
+    ]
 )

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1,42 +1,48 @@
 from mock import Mock, patch
 from nose.tools import assert_equal
 from geckoboard.api import get, put, post, delete
-import requests
 
 API_HOST = 'https://api.geckoboard.com'
 PATH = '/bar'
 API_KEY = 'ABC'
-BODY = { 'foo': 'bar' }
+BODY = {'foo': 'bar'}
 MOCK_RESPONSE = Mock(status_code=200)
+
 
 @patch('requests.get')
 def test_get_makes_network_request(mock_requests_get):
-  mock_requests_get.return_value = MOCK_RESPONSE
-  response = get(PATH, API_KEY)
+    mock_requests_get.return_value = MOCK_RESPONSE
+    response = get(PATH, API_KEY)
 
-  mock_requests_get.assert_called_with(API_HOST + PATH, auth=(API_KEY, ''))
-  assert_equal(response, MOCK_RESPONSE)
+    mock_requests_get.assert_called_with(API_HOST + PATH, auth=(API_KEY, ''))
+    assert_equal(response, MOCK_RESPONSE)
+
 
 @patch('requests.put')
 def test_put_makes_network_request(mock_requests_put):
-  mock_requests_put.return_value = MOCK_RESPONSE
-  response = put(PATH, BODY, API_KEY)
+    mock_requests_put.return_value = MOCK_RESPONSE
+    response = put(PATH, BODY, API_KEY)
 
-  mock_requests_put.assert_called_with(API_HOST + PATH, json=BODY, auth=(API_KEY, ''))
-  assert_equal(response, MOCK_RESPONSE)
+    mock_requests_put.assert_called_with(
+        API_HOST + PATH, json=BODY, auth=(API_KEY, ''))
+    assert_equal(response, MOCK_RESPONSE)
+
 
 @patch('requests.post')
 def test_post_makes_network_request(mock_requests_post):
-  mock_requests_post.return_value = MOCK_RESPONSE
-  response = post(PATH, BODY, API_KEY)
+    mock_requests_post.return_value = MOCK_RESPONSE
+    response = post(PATH, BODY, API_KEY)
 
-  mock_requests_post.assert_called_with(API_HOST + PATH, json=BODY, auth=(API_KEY, ''))
-  assert_equal(response, MOCK_RESPONSE)
+    mock_requests_post.assert_called_with(
+        API_HOST + PATH, json=BODY, auth=(API_KEY, ''))
+    assert_equal(response, MOCK_RESPONSE)
+
 
 @patch('requests.delete')
 def test_delete_makes_network_request(mock_requests_delete):
-  mock_requests_delete.return_value = MOCK_RESPONSE
-  response = delete(PATH, API_KEY)
+    mock_requests_delete.return_value = MOCK_RESPONSE
+    response = delete(PATH, API_KEY)
 
-  mock_requests_delete.assert_called_with(API_HOST + PATH, auth=(API_KEY, ''))
-  assert_equal(response, MOCK_RESPONSE)
+    mock_requests_delete.assert_called_with(
+        API_HOST + PATH, auth=(API_KEY, ''))
+    assert_equal(response, MOCK_RESPONSE)

--- a/tests/client_datasets_delete_test.py
+++ b/tests/client_datasets_delete_test.py
@@ -6,34 +6,37 @@ API_KEY = 'ABC'
 ERROR_MESSAGE = 'Whoops!'
 DATASET_ID = 'Sales.by_day'
 
+
 @patch('geckoboard.api.delete')
 def test_makes_api_call(mock_api_delete):
-  mock_api_delete.return_value = Mock(status_code=200)
-  client = geckoboard.client(API_KEY)
+    mock_api_delete.return_value = Mock(status_code=200)
+    client = geckoboard.client(API_KEY)
 
-  client.datasets.delete(DATASET_ID)
+    client.datasets.delete(DATASET_ID)
 
-  mock_api_delete.assert_called_with('/datasets/' + DATASET_ID, API_KEY)
+    mock_api_delete.assert_called_with('/datasets/' + DATASET_ID, API_KEY)
+
 
 @patch('geckoboard.api.delete')
 def test_returns_true_on_success(mock_api_delete):
-  mock_api_delete.return_value = Mock(status_code=200)
-  client = geckoboard.client(API_KEY)
+    mock_api_delete.return_value = Mock(status_code=200)
+    client = geckoboard.client(API_KEY)
 
-  response = client.datasets.delete(DATASET_ID)
+    response = client.datasets.delete(DATASET_ID)
 
-  assert_equal(response, True)
+    assert_equal(response, True)
+
 
 @patch('geckoboard.api.delete')
 @patch('geckoboard.response_handler.get_error_message')
 def test_rethrows_api_error(mock_get_error_message, mock_api_delete):
-  mock_response = Mock(status_code=401)
-  mock_api_delete.return_value = mock_response
-  mock_get_error_message.return_value = ERROR_MESSAGE
-  client = geckoboard.client(API_KEY)
+    mock_response = Mock(status_code=401)
+    mock_api_delete.return_value = mock_response
+    mock_get_error_message.return_value = ERROR_MESSAGE
+    client = geckoboard.client(API_KEY)
 
-  try:
-    client.datasets.delete(DATASET_ID)
-  except Exception as err:
-    mock_get_error_message.assert_called_with(mock_response)
-    assert_equal(err.message, ERROR_MESSAGE)
+    try:
+        client.datasets.delete(DATASET_ID)
+    except Exception as err:
+        mock_get_error_message.assert_called_with(mock_response)
+        assert_equal(err.message, ERROR_MESSAGE)

--- a/tests/client_datasets_find_or_create_test.py
+++ b/tests/client_datasets_find_or_create_test.py
@@ -7,56 +7,60 @@ API_KEY = 'ABC'
 ERROR_MESSAGE = 'Whoops!'
 DATASET_ID = 'Sales.by_day'
 UNIQUE_BY = 'timestamp'
-FIELDS = { 
-  'amount': { 'foo': 'bar' },
-  'timestamp': { 'foo': 'bar' },
+FIELDS = {
+    'amount': {'foo': 'bar'},
+    'timestamp': {'foo': 'bar'},
 }
+
 
 @patch('geckoboard.api.put')
 def test_makes_api_call(mock_api_put):
-  mock_api_put.return_value = Mock(status_code=200)
-  client = geckoboard.client(API_KEY)
+    mock_api_put.return_value = Mock(status_code=200)
+    client = geckoboard.client(API_KEY)
 
-  client.datasets.find_or_create(DATASET_ID, FIELDS)
+    client.datasets.find_or_create(DATASET_ID, FIELDS)
 
-  mock_api_put.assert_called_with(
-    '/datasets/' + DATASET_ID, 
-    { 'fields': FIELDS }, 
-    API_KEY
-  )
+    mock_api_put.assert_called_with(
+        '/datasets/' + DATASET_ID,
+        {'fields': FIELDS},
+        API_KEY
+    )
+
 
 @patch('geckoboard.api.put')
 def test_handles_unique_by(mock_api_put):
-  mock_api_put.return_value = Mock(status_code=200)
-  client = geckoboard.client(API_KEY)
+    mock_api_put.return_value = Mock(status_code=200)
+    client = geckoboard.client(API_KEY)
 
-  client.datasets.find_or_create(DATASET_ID, FIELDS, UNIQUE_BY)
+    client.datasets.find_or_create(DATASET_ID, FIELDS, UNIQUE_BY)
 
-  mock_api_put.assert_called_with(
-    '/datasets/' + DATASET_ID, 
-    { 'fields': FIELDS, 'unique_by': UNIQUE_BY }, 
-    API_KEY
-  )
+    mock_api_put.assert_called_with(
+        '/datasets/' + DATASET_ID,
+        {'fields': FIELDS, 'unique_by': UNIQUE_BY},
+        API_KEY
+    )
+
 
 @patch('geckoboard.api.put')
 def test_returns_dataset(mock_api_put):
-  mock_api_put.return_value = Mock(status_code=200)
-  client = geckoboard.client(API_KEY)
+    mock_api_put.return_value = Mock(status_code=200)
+    client = geckoboard.client(API_KEY)
 
-  dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
+    dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
 
-  assert_true(isinstance(dataset, Dataset))
+    assert_true(isinstance(dataset, Dataset))
+
 
 @patch('geckoboard.api.put')
 @patch('geckoboard.response_handler.get_error_message')
 def test_rethrows_api_error(mock_get_error_message, mock_api_put):
-  mock_response = Mock(status_code=401)
-  mock_api_put.return_value = mock_response
-  mock_get_error_message.return_value = ERROR_MESSAGE
-  client = geckoboard.client(API_KEY)
+    mock_response = Mock(status_code=401)
+    mock_api_put.return_value = mock_response
+    mock_get_error_message.return_value = ERROR_MESSAGE
+    client = geckoboard.client(API_KEY)
 
-  try:
-    client.datasets.find_or_create(DATASET_ID, FIELDS)
-  except Exception as err:
-    mock_get_error_message.assert_called_with(mock_response)
-    assert_equal(err.message, ERROR_MESSAGE)
+    try:
+        client.datasets.find_or_create(DATASET_ID, FIELDS)
+    except Exception as err:
+        mock_get_error_message.assert_called_with(mock_response)
+        assert_equal(err.message, ERROR_MESSAGE)

--- a/tests/client_ping_test.py
+++ b/tests/client_ping_test.py
@@ -5,34 +5,37 @@ import geckoboard
 API_KEY = 'ABC'
 ERROR_MESSAGE = 'Whoops!'
 
+
 @patch('geckoboard.api.get')
 def test_makes_api_call(mock_api_get):
-  mock_api_get.return_value = Mock(status_code=200)
-  client = geckoboard.client(API_KEY)
+    mock_api_get.return_value = Mock(status_code=200)
+    client = geckoboard.client(API_KEY)
 
-  client.ping()
+    client.ping()
 
-  mock_api_get.assert_called_with('/', API_KEY)
+    mock_api_get.assert_called_with('/', API_KEY)
+
 
 @patch('geckoboard.api.get')
 def test_returns_true_on_success(mock_api_get):
-  mock_api_get.return_value = Mock(status_code=200)
-  client = geckoboard.client(API_KEY)
+    mock_api_get.return_value = Mock(status_code=200)
+    client = geckoboard.client(API_KEY)
 
-  response = client.ping()
+    response = client.ping()
 
-  assert_equal(response, True)
+    assert_equal(response, True)
+
 
 @patch('geckoboard.api.get')
 @patch('geckoboard.response_handler.get_error_message')
 def test_rethrows_api_error(mock_get_error_message, mock_api_get):
-  mock_response = Mock(status_code=401)
-  mock_api_get.return_value = mock_response
-  mock_get_error_message.return_value = ERROR_MESSAGE
-  client = geckoboard.client(API_KEY)
+    mock_response = Mock(status_code=401)
+    mock_api_get.return_value = mock_response
+    mock_get_error_message.return_value = ERROR_MESSAGE
+    client = geckoboard.client(API_KEY)
 
-  try:
-    client.ping()
-  except Exception as err:
-    mock_get_error_message.assert_called_with(mock_response)
-    assert_equal(err.message, ERROR_MESSAGE)
+    try:
+        client.ping()
+    except Exception as err:
+        mock_get_error_message.assert_called_with(mock_response)
+        assert_equal(err.message, ERROR_MESSAGE)

--- a/tests/dataset_delete_test.py
+++ b/tests/dataset_delete_test.py
@@ -7,43 +7,46 @@ ERROR_MESSAGE = 'Whoops!'
 DATASET_ID = 'Sales.by_day'
 FIELDS = {}
 
+
 @patch('geckoboard.api.put')
 @patch('geckoboard.api.delete')
 def test_makes_api_call(mock_api_delete, mock_api_put):
-  mock_api_put.return_value = Mock(status_code=200)
-  mock_api_delete.return_value = Mock(status_code=200)
-  client = geckoboard.client(API_KEY)
-  dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
+    mock_api_put.return_value = Mock(status_code=200)
+    mock_api_delete.return_value = Mock(status_code=200)
+    client = geckoboard.client(API_KEY)
+    dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
 
-  dataset.delete()
+    dataset.delete()
 
-  mock_api_delete.assert_called_with('/datasets/' + DATASET_ID, API_KEY)
+    mock_api_delete.assert_called_with('/datasets/' + DATASET_ID, API_KEY)
+
 
 @patch('geckoboard.api.put')
 @patch('geckoboard.api.delete')
 def test_returns_true_on_success(mock_api_delete, mock_api_put):
-  mock_api_put.return_value = Mock(status_code=200)
-  mock_api_delete.return_value = Mock(status_code=200)
-  client = geckoboard.client(API_KEY)
-  dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
+    mock_api_put.return_value = Mock(status_code=200)
+    mock_api_delete.return_value = Mock(status_code=200)
+    client = geckoboard.client(API_KEY)
+    dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
 
-  response = dataset.delete()
+    response = dataset.delete()
 
-  assert_equal(response, True)
+    assert_equal(response, True)
+
 
 @patch('geckoboard.api.put')
 @patch('geckoboard.api.delete')
 @patch('geckoboard.response_handler.get_error_message')
 def test_rethrows_api_error(mock_get_error_message, mock_api_delete, mock_api_put):
-  mock_response = Mock(status_code=401)
-  mock_api_put.return_value = Mock(status_code=200)
-  mock_api_delete.return_value = mock_response
-  mock_get_error_message.return_value = ERROR_MESSAGE
-  client = geckoboard.client(API_KEY)
-  dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
+    mock_response = Mock(status_code=401)
+    mock_api_put.return_value = Mock(status_code=200)
+    mock_api_delete.return_value = mock_response
+    mock_get_error_message.return_value = ERROR_MESSAGE
+    client = geckoboard.client(API_KEY)
+    dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
 
-  try:
-    dataset.delete()
-  except Exception as err:
-    mock_get_error_message.assert_called_with(mock_response)
-    assert_equal(err.message, ERROR_MESSAGE)
+    try:
+        dataset.delete()
+    except Exception as err:
+        mock_get_error_message.assert_called_with(mock_response)
+        assert_equal(err.message, ERROR_MESSAGE)

--- a/tests/dataset_post_test.py
+++ b/tests/dataset_post_test.py
@@ -7,69 +7,73 @@ ERROR_MESSAGE = 'Whoops!'
 DATASET_ID = 'Sales.by_day'
 DELETE_BY = 'amount'
 UNIQUE_BY = 'timestamp'
-ITEMS = [{ 'amount' : 123 }]
-FIELDS = { 
-  'amount': { 'foo': 'bar' },
-  'timestamp': { 'foo': 'bar' },
+ITEMS = [{'amount': 123}]
+FIELDS = {
+    'amount': {'foo': 'bar'},
+    'timestamp': {'foo': 'bar'},
 }
+
 
 @patch('geckoboard.api.put')
 @patch('geckoboard.api.post')
 def test_makes_api_call(mock_api_post, mock_api_put):
-  mock_api_put.return_value = Mock(status_code=200)
-  mock_api_post.return_value = Mock(status_code=200)
-  client = geckoboard.client(API_KEY)
-  dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
+    mock_api_put.return_value = Mock(status_code=200)
+    mock_api_post.return_value = Mock(status_code=200)
+    client = geckoboard.client(API_KEY)
+    dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
 
-  dataset.post(ITEMS)
+    dataset.post(ITEMS)
 
-  mock_api_post.assert_called_with(
-    '/datasets/' + DATASET_ID + '/data',
-    { 'data': ITEMS },
-    API_KEY
-  )
+    mock_api_post.assert_called_with(
+        '/datasets/' + DATASET_ID + '/data',
+        {'data': ITEMS},
+        API_KEY
+    )
+
 
 @patch('geckoboard.api.put')
 @patch('geckoboard.api.post')
 def test_handles_delete_by(mock_api_post, mock_api_put):
-  mock_api_put.return_value = Mock(status_code=200)
-  mock_api_post.return_value = Mock(status_code=200)
-  client = geckoboard.client(API_KEY)
-  dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
+    mock_api_put.return_value = Mock(status_code=200)
+    mock_api_post.return_value = Mock(status_code=200)
+    client = geckoboard.client(API_KEY)
+    dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
 
-  dataset.post(ITEMS, DELETE_BY)
+    dataset.post(ITEMS, DELETE_BY)
 
-  mock_api_post.assert_called_with(
-    '/datasets/' + DATASET_ID + '/data',
-    { 'data': ITEMS, 'delete_by': DELETE_BY },
-    API_KEY
-  )
+    mock_api_post.assert_called_with(
+        '/datasets/' + DATASET_ID + '/data',
+        {'data': ITEMS, 'delete_by': DELETE_BY},
+        API_KEY
+    )
+
 
 @patch('geckoboard.api.put')
 @patch('geckoboard.api.post')
 def test_returns_true_on_success(mock_api_post, mock_api_put):
-  mock_api_put.return_value = Mock(status_code=200)
-  mock_api_post.return_value = Mock(status_code=200)
-  client = geckoboard.client(API_KEY)
-  dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
+    mock_api_put.return_value = Mock(status_code=200)
+    mock_api_post.return_value = Mock(status_code=200)
+    client = geckoboard.client(API_KEY)
+    dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
 
-  response = dataset.post(ITEMS)
+    response = dataset.post(ITEMS)
 
-  assert_equal(response, True)
+    assert_equal(response, True)
+
 
 @patch('geckoboard.api.put')
 @patch('geckoboard.api.post')
 @patch('geckoboard.response_handler.get_error_message')
 def test_rethrows_api_error(mock_get_error_message, mock_api_post, mock_api_put):
-  mock_response = Mock(status_code=401)
-  mock_api_put.return_value = Mock(status_code=200)
-  mock_api_post.return_value = mock_response
-  mock_get_error_message.return_value = ERROR_MESSAGE
-  client = geckoboard.client(API_KEY)
-  dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
+    mock_response = Mock(status_code=401)
+    mock_api_put.return_value = Mock(status_code=200)
+    mock_api_post.return_value = mock_response
+    mock_get_error_message.return_value = ERROR_MESSAGE
+    client = geckoboard.client(API_KEY)
+    dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
 
-  try:
-    dataset.post(ITEMS)
-  except Exception as err:
-    mock_get_error_message.assert_called_with(mock_response)
-    assert_equal(err.message, ERROR_MESSAGE)
+    try:
+        dataset.post(ITEMS)
+    except Exception as err:
+        mock_get_error_message.assert_called_with(mock_response)
+        assert_equal(err.message, ERROR_MESSAGE)

--- a/tests/dataset_put_test.py
+++ b/tests/dataset_put_test.py
@@ -6,47 +6,50 @@ API_KEY = 'ABC'
 ERROR_MESSAGE = 'Whoops!'
 DATASET_ID = 'Sales.by_day'
 FIELDS = {}
-ITEMS = [{ 'amount' : 123 }]
+ITEMS = [{'amount': 123}]
+
 
 @patch('geckoboard.api.put')
 def test_makes_api_call(mock_api_put):
-  mock_api_put.return_value = Mock(status_code=200)
-  client = geckoboard.client(API_KEY)
-  dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
+    mock_api_put.return_value = Mock(status_code=200)
+    client = geckoboard.client(API_KEY)
+    dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
 
-  dataset.put(ITEMS)
+    dataset.put(ITEMS)
 
-  mock_api_put.assert_called_with(
-    '/datasets/' + DATASET_ID + '/data',
-    { 'data': ITEMS },
-    API_KEY
-  )
+    mock_api_put.assert_called_with(
+        '/datasets/' + DATASET_ID + '/data',
+        {'data': ITEMS},
+        API_KEY
+    )
+
 
 @patch('geckoboard.api.put')
 def test_returns_true_on_success(mock_api_put):
-  mock_api_put.return_value = Mock(status_code=200)
-  client = geckoboard.client(API_KEY)
-  dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
+    mock_api_put.return_value = Mock(status_code=200)
+    client = geckoboard.client(API_KEY)
+    dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
 
-  response = dataset.put(ITEMS)
+    response = dataset.put(ITEMS)
 
-  assert_equal(response, True)
+    assert_equal(response, True)
+
 
 @patch('geckoboard.api.put')
 @patch('geckoboard.response_handler.get_error_message')
 def test_rethrows_api_error(mock_get_error_message, mock_api_put):
-  # Make the initial put pass so we can create the dataset
-  mock_api_put.return_value = Mock(status_code=200)
-  client = geckoboard.client(API_KEY)
-  dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
+    # Make the initial put pass so we can create the dataset
+    mock_api_put.return_value = Mock(status_code=200)
+    client = geckoboard.client(API_KEY)
+    dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
 
-  # Now make it fail so we can test the error response
-  mock_response = Mock(status_code=401)
-  mock_api_put.return_value = mock_response
-  mock_get_error_message.return_value = ERROR_MESSAGE
+    # Now make it fail so we can test the error response
+    mock_response = Mock(status_code=401)
+    mock_api_put.return_value = mock_response
+    mock_get_error_message.return_value = ERROR_MESSAGE
 
-  try:
-    dataset.put(ITEMS)
-  except Exception as err:
-    mock_get_error_message.assert_called_with(mock_response)
-    assert_equal(err.message, ERROR_MESSAGE)
+    try:
+        dataset.put(ITEMS)
+    except Exception as err:
+        mock_get_error_message.assert_called_with(mock_response)
+        assert_equal(err.message, ERROR_MESSAGE)


### PR DESCRIPTION
https://app.clubhouse.io/geckoboard/story/15702/improve-documentation-of-python-datasets-client

We had a great suggestion from a user to add docstring annotation, specifically to document expected parameter types... so that's what this change does.

And now the editor provides additional help when using our library...

![image](https://user-images.githubusercontent.com/6588325/31821062-aa4b5390-b59b-11e7-8090-b7fce1988348.png)
![image](https://user-images.githubusercontent.com/6588325/31821135-fb71d8e8-b59b-11e7-864e-fe141e42fd43.png)

In this change I've also added consistent formatting using `autopep8` so it would make sense to view the changes with whitespace removed https://github.com/geckoboard/geckoboard-python/pull/1/files?w=1