### PR TITLE
Added support for timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ dataset.delete() # => true
 
 ---
 
+## Timeout
+To enable timeouts for requests package
+```python
+import geckoboard
+
+client = geckoboard.client(API_KEY, timeout=60)
+# or as positional parameter
+client = geckoboard.client(API_KEY, 60)
+```
+
 ## Development
 
 Clone this repo

--- a/geckoboard/__init__.py
+++ b/geckoboard/__init__.py
@@ -9,7 +9,7 @@ you can create, update and delete datasets.
 from geckoboard.client import Client
 
 
-def client(api_key):
+def client(api_key, timeout=None):
     """
     Creates an instance of a Geckoboard API client
 
@@ -25,10 +25,12 @@ def client(api_key):
     ----------
     api_key : str
         Your Geckoboard API key
+    timeout : float
+        Optional timeout parameter
 
     Returns
     -------
     Client
         A Geckoboard API client instance
     """
-    return Client(api_key)
+    return Client(api_key, timeout)

--- a/geckoboard/api.py
+++ b/geckoboard/api.py
@@ -7,17 +7,17 @@ import requests
 API_HOST = 'https://api.geckoboard.com'
 
 
-def get(path, api_key):
-    return requests.get(API_HOST + path, auth=(api_key, ''))
+def get(path, api_key, timeout=None):
+    return requests.get(API_HOST + path, auth=(api_key, ''), timeout=timeout)
 
 
-def delete(path, api_key):
-    return requests.delete(API_HOST + path, auth=(api_key, ''))
+def delete(path, api_key, timeout=None):
+    return requests.delete(API_HOST + path, auth=(api_key, ''), timeout=timeout)
 
 
-def post(path, body, api_key):
-    return requests.post(API_HOST + path, json=body, auth=(api_key, ''))
+def post(path, body, api_key, timeout=None):
+    return requests.post(API_HOST + path, json=body, auth=(api_key, ''), timeout=timeout)
 
 
-def put(path, body, api_key):
-    return requests.put(API_HOST + path, json=body, auth=(api_key, ''))
+def put(path, body, api_key, timeout=None):
+    return requests.put(API_HOST + path, json=body, auth=(api_key, ''), timeout=timeout)

--- a/geckoboard/client.py
+++ b/geckoboard/client.py
@@ -6,7 +6,7 @@ from geckoboard.connection import Connection
 from geckoboard.datasets_client import DatasetsClient
 
 
-class Client():
+class Client:
     """
     The Geckoboard API client
 
@@ -29,8 +29,8 @@ class Client():
         The datasets client can find, create and delete your datasets
     """
 
-    def __init__(self, api_key):
-        connection = Connection(api_key)
+    def __init__(self, api_key, timeout=None):
+        connection = Connection(api_key, timeout=timeout)
 
         self.__connection = connection
         self.datasets = DatasetsClient(connection)

--- a/geckoboard/connection.py
+++ b/geckoboard/connection.py
@@ -9,27 +9,29 @@ from geckoboard import api
 from geckoboard import response_handler
 
 
-class Connection():
-    def __init__(self, api_key):
+class Connection:
+    def __init__(self, api_key, timeout=None):
         self.api_key = api_key
+        self.timeout = timeout
 
     def get(self, path):
-        response = api.get(path, self.api_key)
+        response = api.get(path, self.api_key, self.timeout)
         return self.handle_response(response)
 
     def delete(self, path):
-        response = api.delete(path, self.api_key)
+        response = api.delete(path, self.api_key, self.timeout)
         return self.handle_response(response)
 
     def post(self, path, body):
-        response = api.post(path, body, self.api_key)
+        response = api.post(path, body, self.api_key, self.timeout)
         return self.handle_response(response)
 
     def put(self, path, body):
-        response = api.put(path, body, self.api_key)
+        response = api.put(path, body, self.api_key, self.timeout)
         return self.handle_response(response)
 
-    def handle_response(self, response):
+    @staticmethod
+    def handle_response(response):
         if response.status_code < 200 or response.status_code >= 300:
             raise Exception(response_handler.get_error_message(response))
 

--- a/geckoboard/dataset.py
+++ b/geckoboard/dataset.py
@@ -3,7 +3,7 @@ Public class: Dataset
 """
 
 
-class Dataset():
+class Dataset:
     """
     Update or delete an individual dataset.
 

--- a/geckoboard/datasets_client.py
+++ b/geckoboard/datasets_client.py
@@ -5,7 +5,7 @@ Public class: DatasetsClient
 from geckoboard.dataset import Dataset
 
 
-class DatasetsClient():
+class DatasetsClient:
     """
     The datasets API client
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -7,42 +7,70 @@ PATH = '/bar'
 API_KEY = 'ABC'
 BODY = {'foo': 'bar'}
 MOCK_RESPONSE = Mock(status_code=200)
+TIMEOUT = 50
 
 
 @patch('requests.get')
 def test_get_makes_network_request(mock_requests_get):
     mock_requests_get.return_value = MOCK_RESPONSE
-    response = get(PATH, API_KEY)
+    response = get(PATH, API_KEY, timeout=TIMEOUT)
 
-    mock_requests_get.assert_called_with(API_HOST + PATH, auth=(API_KEY, ''))
+    mock_requests_get.assert_called_with(
+        API_HOST + PATH,
+        auth=(API_KEY, ''),
+        timeout=TIMEOUT
+    )
     assert_equal(response, MOCK_RESPONSE)
 
 
 @patch('requests.put')
 def test_put_makes_network_request(mock_requests_put):
     mock_requests_put.return_value = MOCK_RESPONSE
-    response = put(PATH, BODY, API_KEY)
+    response = put(PATH, BODY, API_KEY, timeout=TIMEOUT)
 
     mock_requests_put.assert_called_with(
-        API_HOST + PATH, json=BODY, auth=(API_KEY, ''))
+        API_HOST + PATH,
+        json=BODY,
+        auth=(API_KEY, ''),
+        timeout=TIMEOUT)
     assert_equal(response, MOCK_RESPONSE)
 
 
 @patch('requests.post')
 def test_post_makes_network_request(mock_requests_post):
     mock_requests_post.return_value = MOCK_RESPONSE
-    response = post(PATH, BODY, API_KEY)
+    response = post(PATH, BODY, API_KEY, timeout=TIMEOUT)
 
     mock_requests_post.assert_called_with(
-        API_HOST + PATH, json=BODY, auth=(API_KEY, ''))
+        API_HOST + PATH,
+        json=BODY,
+        auth=(API_KEY, ''),
+        timeout=TIMEOUT
+    )
     assert_equal(response, MOCK_RESPONSE)
 
 
 @patch('requests.delete')
 def test_delete_makes_network_request(mock_requests_delete):
     mock_requests_delete.return_value = MOCK_RESPONSE
-    response = delete(PATH, API_KEY)
+    response = delete(PATH, API_KEY, timeout=TIMEOUT)
 
     mock_requests_delete.assert_called_with(
-        API_HOST + PATH, auth=(API_KEY, ''))
+        API_HOST + PATH,
+        auth=(API_KEY, ''),
+        timeout=TIMEOUT
+    )
+    assert_equal(response, MOCK_RESPONSE)
+
+
+@patch('requests.get')
+def test_default_timeout(mock_requests_get):
+    mock_requests_get.return_value = MOCK_RESPONSE
+    response = get(PATH, API_KEY)
+
+    mock_requests_get.assert_called_with(
+        API_HOST + PATH,
+        auth=(API_KEY, ''),
+        timeout=None
+    )
     assert_equal(response, MOCK_RESPONSE)

--- a/tests/client_datasets_delete_test.py
+++ b/tests/client_datasets_delete_test.py
@@ -5,22 +5,23 @@ import geckoboard
 API_KEY = 'ABC'
 ERROR_MESSAGE = 'Whoops!'
 DATASET_ID = 'Sales.by_day'
+TIMEOUT = 50
 
 
 @patch('geckoboard.api.delete')
 def test_makes_api_call(mock_api_delete):
     mock_api_delete.return_value = Mock(status_code=200)
-    client = geckoboard.client(API_KEY)
+    client = geckoboard.client(API_KEY, timeout=0)
 
     client.datasets.delete(DATASET_ID)
 
-    mock_api_delete.assert_called_with('/datasets/' + DATASET_ID, API_KEY)
+    mock_api_delete.assert_called_with('/datasets/' + DATASET_ID, API_KEY, 0)
 
 
 @patch('geckoboard.api.delete')
 def test_returns_true_on_success(mock_api_delete):
     mock_api_delete.return_value = Mock(status_code=200)
-    client = geckoboard.client(API_KEY)
+    client = geckoboard.client(API_KEY, timeout=TIMEOUT)
 
     response = client.datasets.delete(DATASET_ID)
 
@@ -33,7 +34,7 @@ def test_rethrows_api_error(mock_get_error_message, mock_api_delete):
     mock_response = Mock(status_code=401)
     mock_api_delete.return_value = mock_response
     mock_get_error_message.return_value = ERROR_MESSAGE
-    client = geckoboard.client(API_KEY)
+    client = geckoboard.client(API_KEY, timeout=TIMEOUT)
 
     try:
         client.datasets.delete(DATASET_ID)

--- a/tests/client_datasets_find_or_create_test.py
+++ b/tests/client_datasets_find_or_create_test.py
@@ -8,43 +8,46 @@ ERROR_MESSAGE = 'Whoops!'
 DATASET_ID = 'Sales.by_day'
 UNIQUE_BY = 'timestamp'
 FIELDS = {
-    'amount': {'foo': 'bar'},
+    'amount':    {'foo': 'bar'},
     'timestamp': {'foo': 'bar'},
 }
+TIMEOUT = 50
 
 
 @patch('geckoboard.api.put')
 def test_makes_api_call(mock_api_put):
     mock_api_put.return_value = Mock(status_code=200)
-    client = geckoboard.client(API_KEY)
+    client = geckoboard.client(API_KEY, timeout=TIMEOUT)
 
     client.datasets.find_or_create(DATASET_ID, FIELDS)
 
     mock_api_put.assert_called_with(
         '/datasets/' + DATASET_ID,
         {'fields': FIELDS},
-        API_KEY
+        API_KEY,
+        TIMEOUT
     )
 
 
 @patch('geckoboard.api.put')
 def test_handles_unique_by(mock_api_put):
     mock_api_put.return_value = Mock(status_code=200)
-    client = geckoboard.client(API_KEY)
+    client = geckoboard.client(API_KEY, timeout=TIMEOUT)
 
     client.datasets.find_or_create(DATASET_ID, FIELDS, UNIQUE_BY)
 
     mock_api_put.assert_called_with(
         '/datasets/' + DATASET_ID,
         {'fields': FIELDS, 'unique_by': UNIQUE_BY},
-        API_KEY
+        API_KEY,
+        TIMEOUT
     )
 
 
 @patch('geckoboard.api.put')
 def test_returns_dataset(mock_api_put):
     mock_api_put.return_value = Mock(status_code=200)
-    client = geckoboard.client(API_KEY)
+    client = geckoboard.client(API_KEY, timeout=TIMEOUT)
 
     dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
 
@@ -57,7 +60,7 @@ def test_rethrows_api_error(mock_get_error_message, mock_api_put):
     mock_response = Mock(status_code=401)
     mock_api_put.return_value = mock_response
     mock_get_error_message.return_value = ERROR_MESSAGE
-    client = geckoboard.client(API_KEY)
+    client = geckoboard.client(API_KEY, timeout=TIMEOUT)
 
     try:
         client.datasets.find_or_create(DATASET_ID, FIELDS)

--- a/tests/client_ping_test.py
+++ b/tests/client_ping_test.py
@@ -4,16 +4,17 @@ import geckoboard
 
 API_KEY = 'ABC'
 ERROR_MESSAGE = 'Whoops!'
+TIMEOUT = 50
 
 
 @patch('geckoboard.api.get')
 def test_makes_api_call(mock_api_get):
     mock_api_get.return_value = Mock(status_code=200)
-    client = geckoboard.client(API_KEY)
+    client = geckoboard.client(API_KEY, timeout=TIMEOUT)
 
     client.ping()
 
-    mock_api_get.assert_called_with('/', API_KEY)
+    mock_api_get.assert_called_with('/', API_KEY, TIMEOUT)
 
 
 @patch('geckoboard.api.get')

--- a/tests/dataset_delete_test.py
+++ b/tests/dataset_delete_test.py
@@ -6,6 +6,7 @@ API_KEY = 'ABC'
 ERROR_MESSAGE = 'Whoops!'
 DATASET_ID = 'Sales.by_day'
 FIELDS = {}
+TIMEOUT = 50
 
 
 @patch('geckoboard.api.put')
@@ -13,12 +14,12 @@ FIELDS = {}
 def test_makes_api_call(mock_api_delete, mock_api_put):
     mock_api_put.return_value = Mock(status_code=200)
     mock_api_delete.return_value = Mock(status_code=200)
-    client = geckoboard.client(API_KEY)
+    client = geckoboard.client(API_KEY, timeout=TIMEOUT)
     dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
 
     dataset.delete()
 
-    mock_api_delete.assert_called_with('/datasets/' + DATASET_ID, API_KEY)
+    mock_api_delete.assert_called_with('/datasets/' + DATASET_ID, API_KEY, TIMEOUT)
 
 
 @patch('geckoboard.api.put')

--- a/tests/dataset_post_test.py
+++ b/tests/dataset_post_test.py
@@ -12,6 +12,7 @@ FIELDS = {
     'amount': {'foo': 'bar'},
     'timestamp': {'foo': 'bar'},
 }
+TIMEOUT = 50
 
 
 @patch('geckoboard.api.put')
@@ -19,7 +20,7 @@ FIELDS = {
 def test_makes_api_call(mock_api_post, mock_api_put):
     mock_api_put.return_value = Mock(status_code=200)
     mock_api_post.return_value = Mock(status_code=200)
-    client = geckoboard.client(API_KEY)
+    client = geckoboard.client(API_KEY, timeout=TIMEOUT)
     dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
 
     dataset.post(ITEMS)
@@ -27,7 +28,8 @@ def test_makes_api_call(mock_api_post, mock_api_put):
     mock_api_post.assert_called_with(
         '/datasets/' + DATASET_ID + '/data',
         {'data': ITEMS},
-        API_KEY
+        API_KEY,
+        TIMEOUT
     )
 
 
@@ -36,7 +38,7 @@ def test_makes_api_call(mock_api_post, mock_api_put):
 def test_handles_delete_by(mock_api_post, mock_api_put):
     mock_api_put.return_value = Mock(status_code=200)
     mock_api_post.return_value = Mock(status_code=200)
-    client = geckoboard.client(API_KEY)
+    client = geckoboard.client(API_KEY, timeout=TIMEOUT)
     dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
 
     dataset.post(ITEMS, DELETE_BY)
@@ -44,7 +46,8 @@ def test_handles_delete_by(mock_api_post, mock_api_put):
     mock_api_post.assert_called_with(
         '/datasets/' + DATASET_ID + '/data',
         {'data': ITEMS, 'delete_by': DELETE_BY},
-        API_KEY
+        API_KEY,
+        TIMEOUT
     )
 
 

--- a/tests/dataset_put_test.py
+++ b/tests/dataset_put_test.py
@@ -7,12 +7,13 @@ ERROR_MESSAGE = 'Whoops!'
 DATASET_ID = 'Sales.by_day'
 FIELDS = {}
 ITEMS = [{'amount': 123}]
+TIMEOUT = 50
 
 
 @patch('geckoboard.api.put')
 def test_makes_api_call(mock_api_put):
     mock_api_put.return_value = Mock(status_code=200)
-    client = geckoboard.client(API_KEY)
+    client = geckoboard.client(API_KEY, timeout=TIMEOUT)
     dataset = client.datasets.find_or_create(DATASET_ID, FIELDS)
 
     dataset.put(ITEMS)
@@ -20,7 +21,8 @@ def test_makes_api_call(mock_api_put):
     mock_api_put.assert_called_with(
         '/datasets/' + DATASET_ID + '/data',
         {'data': ITEMS},
-        API_KEY
+        API_KEY,
+        TIMEOUT
     )
 
 


### PR DESCRIPTION
Sometimes we experience that a job hangs. Implementing timeouts to enable a request to stop itself if it doesn't finish in time.

https://requests.readthedocs.io/en/master/user/quickstart/#timeouts